### PR TITLE
update test/dune, Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ deps: ## Install development dependencies
 
 .PHONY: create_switch
 create_switch:
-	opam switch create . --no-install --locked
+	opam switch create . ocaml-base-compiler.4.11.0 --no-install --locked
 
 .PHONY: switch
 switch: create_switch deps ## Create an opam switch and install development dependencies

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,4 @@
-(test
+(executable
  (name test)
  (libraries sihl service database alcotest alcotest-lwt
    caqti-driver-postgresql pizza))


### PR DESCRIPTION
These are the changes referenced in https://github.com/oxidizing/sihl-demo/issues/11#issuecomment-896073203 if you want them.

Also, running `make sihl migrate` doesnt work with the current set up on my machine for whatever reason. I get

```sh
2021-08-10T14:48:40-00:00 [INFO] [sihl.core.app]: Setting up...
2021-08-10T14:48:40-00:00 [INFO] [sihl.core.configuration]: SIHL_ENV: development
2021-08-10T14:48:40-00:00 [ERROR] [sihl.core.configuration]: Failed to read configuration 'DATABASE_URL': No value provided
Command 'migrate' aborted after 227us: 'Sihl__Core_configuration.Exception("Invalid configuration provided")'
Raised at Stdlib__map.Make.find in file "map.ml", line 137, characters 10-25
Called from Sexplib0__Sexp_conv.Exn_converter.find_auto in file "src/sexp_conv.ml", line 156, characters 10-37
```

Sticking `.env` values in to `.envrc` and running `direnv allow` gets it work.

Lastly, your Makefile is still using `inotifywait` which is not available on macos.